### PR TITLE
Fixed wrong index for capture group in RegExpExecArray.

### DIFF
--- a/src/engine/compiler.ts
+++ b/src/engine/compiler.ts
@@ -168,8 +168,9 @@ export class Compiler {
   }
 
   private compileCapture(node: Capture): OpCode[] {
+    const current = this.captureParensIndex++;
     const codes0 = this.compileNode(node.child);
-    if (node.index !== this.captureParensIndex++) {
+    if (node.index !== current) {
       throw new Error('BUG: invalid pattern');
     }
     return [
@@ -180,9 +181,10 @@ export class Compiler {
   }
 
   private compileNamedCapture(node: NamedCapture): OpCode[] {
+    const current = this.captureParensIndex++;
     const codes0 = this.compileNode(node.child);
     const index = this.names.get(node.name);
-    if (index === undefined || index !== this.captureParensIndex++) {
+    if (index === undefined || index !== current) {
       throw new Error('BUG: invalid pattern');
     }
     return [{ op: 'cap_begin', index }, ...codes0, { op: 'cap_end', index }];

--- a/src/syntax/parser.ts
+++ b/src/syntax/parser.ts
@@ -991,8 +991,8 @@ export class Parser {
 
     if (!this.source.startsWith('(?', this.pos)) {
       this.pos++; // skip '('
-      const child = this.parseDisjunction();
       const index = ++this.captureParensIndex;
+      const child = this.parseDisjunction();
       if (this.current() !== ')') {
         throw new RegExpSyntaxError('unterminated capture');
       }


### PR DESCRIPTION
~~~js
RegExp('(E(A))').exec('EAC')
[ "EA", "EA", "A" ]

RegExpCompat('(E(A))').exec('EAC')
[ "EA", "A", "EA" ]
~~~

![bug](https://user-images.githubusercontent.com/2511702/150531571-c6218fff-2cbf-4da8-a176-05d488f18cfc.PNG)
